### PR TITLE
Added files/AM_INIT_AUTOMAKE.patch; small fix in catatonit-0.1.7.ebuild

### DIFF
--- a/app-containers/catatonit/catatonit-0.1.7.ebuild
+++ b/app-containers/catatonit/catatonit-0.1.7.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 DESCRIPTION="A container init that is so simple it's effectively brain-dead"
 HOMEPAGE="https://github.com/openSUSE/catatonit"
-SRC_URI="https://github.com/openSUSE/${PN}/archive/v${PV}.tar.gz -> ${PV}.tar.gz"
+SRC_URI="https://github.com/openSUSE/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 RESTRICT="mirror"
 
 LICENSE="GPL-3+"
@@ -16,6 +16,10 @@ DEPEND="
 	sys-devel/autogen
 	sys-devel/libtool
 "
+
+PATCHES=(
+	"${FILESDIR}/AM_INIT_AUTOMAKE.patch"
+)
 
 src_configure() {
 	./autogen.sh

--- a/app-containers/catatonit/files/AM_INIT_AUTOMAKE.patch
+++ b/app-containers/catatonit/files/AM_INIT_AUTOMAKE.patch
@@ -1,0 +1,9 @@
+Index: catatonit-0.1.7/configure.ac
+===================================================================
+--- catatonit-0.1.7.orig/configure.ac
++++ catatonit-0.1.7/configure.ac
+@@ -31,4 +31,3 @@ AC_FUNC_FORK
+ 
+ AC_CONFIG_FILES([Makefile config.h])
+ AC_OUTPUT
+-AM_INIT_AUTOMAKE


### PR DESCRIPTION
app-containers/catatonit-0.1.7: Fix the storage file name to ${P}.tar.gz; Include configure.ac patch needed to fix https://github.com/openSUSE/catatonit/issues/20